### PR TITLE
Add robots.txt and sitemap generation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import remarkMath from 'remark-math';
 import remarkFigureCaption from '@microflash/remark-figure-caption';
@@ -9,6 +10,7 @@ import rehypeYoutubeEmbed from './src/plugins/rehype-youtube-embed.mjs';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://flatmap.io',
+  integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()]
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.14",
+    "@astrojs/sitemap": "^3.2.1",
     "@microflash/remark-figure-caption": "^2.0.2",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.1.4",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+# robots.txt for flatmap.io
+# Allow all crawlers to index all content
+
+User-agent: *
+Allow: /
+
+# Sitemap location
+Sitemap: https://flatmap.io/sitemap-index.xml


### PR DESCRIPTION
- Create permissive robots.txt allowing all crawlers
- Add @astrojs/sitemap integration for automatic sitemap generation
- Sitemap will be generated at /sitemap-index.xml during build

https://claude.ai/code/session_01QkgUHEJNsBhFd9bs1AT29e