### PR TITLE
Add Google Tag Manager integration with environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Google Tag Manager
+# Get your container ID from https://tagmanager.google.com/
+# Format: GTM-XXXXXXX
+PUBLIC_GTM_ID=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Install, build, and upload your site
         uses: withastro/action@v5
-        # with:
-          # path: . # The root location of your Astro project inside the repository. (optional)
-          # node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
-          # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-          # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
-        # env:
-          # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
+        env:
+          PUBLIC_GTM_ID: ${{ secrets.PUBLIC_GTM_ID }}
 
   deploy:
     needs: build

--- a/src/components/GoogleTagManager.astro
+++ b/src/components/GoogleTagManager.astro
@@ -1,0 +1,23 @@
+---
+/**
+ * Google Tag Manager - Head Script
+ *
+ * Place this component in the <head> section of your layout.
+ * Uses environment variable PUBLIC_GTM_ID for the container ID.
+ *
+ * Set PUBLIC_GTM_ID in your .env file:
+ *   PUBLIC_GTM_ID=GTM-XXXXXXX
+ */
+
+const gtmId = import.meta.env.PUBLIC_GTM_ID;
+---
+
+{gtmId && (
+  <script is:inline define:vars={{ gtmId }}>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer',gtmId);
+  </script>
+)}

--- a/src/components/GoogleTagManagerNoScript.astro
+++ b/src/components/GoogleTagManagerNoScript.astro
@@ -1,0 +1,23 @@
+---
+/**
+ * Google Tag Manager - NoScript Fallback
+ *
+ * Place this component immediately after the opening <body> tag.
+ * Provides fallback tracking for users with JavaScript disabled.
+ *
+ * Uses the same PUBLIC_GTM_ID environment variable as GoogleTagManager.astro
+ */
+
+const gtmId = import.meta.env.PUBLIC_GTM_ID;
+---
+
+{gtmId && (
+  <noscript>
+    <iframe
+      src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+      height="0"
+      width="0"
+      style="display:none;visibility:hidden"
+    ></iframe>
+  </noscript>
+)}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,7 @@
 ---
 import '../styles/global.css';
+import GoogleTagManager from '../components/GoogleTagManager.astro';
+import GoogleTagManagerNoScript from '../components/GoogleTagManagerNoScript.astro';
 
 interface Props {
   title?: string;
@@ -43,8 +45,14 @@ const canonicalURL = Astro.site ? new URL(Astro.url.pathname, Astro.site) : new 
 
     <!-- KaTeX for math rendering -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
+
+    <!-- Google Tag Manager -->
+    <GoogleTagManager />
   </head>
   <body class="min-h-screen flex flex-col">
+    <!-- Google Tag Manager (noscript) -->
+    <GoogleTagManagerNoScript />
+
     <header class="border-b border-[var(--color-terminal-fg)]/20 py-4">
       <div class="max-w-4xl mx-auto px-4">
         <nav class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
This PR adds Google Tag Manager (GTM) integration to the project, allowing analytics tracking across the site. The implementation uses environment variables for configuration and includes both script and noscript fallback components.

## Changes
- **Added `.env.example`**: Template file documenting the `PUBLIC_GTM_ID` environment variable with instructions for obtaining a GTM container ID
- **Added `GoogleTagManager.astro` component**: Head script component that loads the GTM tracking script using the configured container ID
- **Added `GoogleTagManagerNoScript.astro` component**: Noscript fallback component for tracking users with JavaScript disabled
- **Updated `BaseLayout.astro`**: Integrated both GTM components into the base layout:
  - GTM script placed in the `<head>` section
  - GTM noscript fallback placed immediately after opening `<body>` tag

## Implementation Details
- Both components check for the presence of `PUBLIC_GTM_ID` before rendering, allowing the feature to be optional
- The GTM container ID is passed via Astro's environment variables (`import.meta.env.PUBLIC_GTM_ID`)
- Uses the official Google Tag Manager implementation script
- Follows GTM best practices for script placement and noscript fallback positioning
- Includes comprehensive JSDoc comments explaining component usage and configuration

https://claude.ai/code/session_014icogmyvaUb67CQCtiEMgU