### PR TITLE
Add line numbers to code blocks

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -125,6 +125,20 @@ pre code {
   border: none;
   padding: 0;
   font-size: 0.9em;
+  counter-reset: line;
+}
+
+pre code .line::before {
+  counter-increment: line;
+  content: counter(line);
+  display: inline-block;
+  width: 2.5em;
+  margin-right: 1em;
+  padding-right: 0.5em;
+  text-align: right;
+  color: rgba(236, 234, 229, 0.3);
+  border-right: 1px solid rgba(236, 234, 229, 0.1);
+  user-select: none;
 }
 
 blockquote {


### PR DESCRIPTION
## Summary
This change adds automatic line numbering to code blocks using CSS counters, improving code readability and making it easier to reference specific lines.

## Changes
- Added `counter-reset: line` to `pre code` elements to initialize line counting
- Created new `pre code .line::before` pseudo-element styles to display line numbers with:
  - Auto-incrementing counter for each line
  - Fixed width (2.5em) right-aligned numbers
  - Subtle styling with low opacity (0.3) to avoid visual clutter
  - Light border separator between numbers and code
  - `user-select: none` to prevent line numbers from being copied with code

## Implementation Details
The line numbers are rendered via CSS `::before` pseudo-elements on `.line` elements within code blocks. The counter-based approach is semantic and doesn't require modifying HTML structure. The styling uses a muted color (`rgba(236, 234, 229, 0.3)`) to keep line numbers visually subordinate to the actual code content.

https://claude.ai/code/session_0141AxdJ1VjPXu2uUcLtojdo