### PR TITLE
Switch line numbers from CSS counters to DOM gutter approach

### DIFF
--- a/src/scripts/code-blocks.js
+++ b/src/scripts/code-blocks.js
@@ -1,4 +1,4 @@
-// Enhance code blocks with language labels and copy buttons
+// Enhance code blocks with language labels, copy buttons, and line numbers
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll("pre.astro-code").forEach((pre) => {
     // Create wrapper container
@@ -39,5 +39,26 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Insert title bar before the code
     wrapper.insertBefore(titleBar, pre);
+
+    // Add line numbers
+    const lines = pre.querySelectorAll(".line");
+    if (lines.length > 0) {
+      const codeWrapper = document.createElement("div");
+      codeWrapper.className = "code-wrapper";
+
+      const gutter = document.createElement("div");
+      gutter.className = "line-numbers";
+      gutter.setAttribute("aria-hidden", "true");
+
+      for (let i = 1; i <= lines.length; i++) {
+        const num = document.createElement("span");
+        num.textContent = String(i);
+        gutter.appendChild(num);
+      }
+
+      pre.parentNode.insertBefore(codeWrapper, pre);
+      codeWrapper.appendChild(gutter);
+      codeWrapper.appendChild(pre);
+    }
   });
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -125,20 +125,27 @@ pre code {
   border: none;
   padding: 0;
   font-size: 0.9em;
-  counter-reset: line;
 }
 
-pre code .line::before {
-  counter-increment: line;
-  content: counter(line);
-  display: inline-block;
-  width: 2.5em;
-  margin-right: 1em;
-  padding-right: 0.5em;
+/* Line numbers gutter */
+.code-wrapper {
+  display: flex;
+}
+
+.line-numbers {
+  flex-shrink: 0;
+  padding: 15px 0;
   text-align: right;
+  user-select: none;
   color: rgba(236, 234, 229, 0.3);
   border-right: 1px solid rgba(236, 234, 229, 0.1);
-  user-select: none;
+  font-size: 0.9em;
+  line-height: 1.54;
+}
+
+.line-numbers span {
+  display: block;
+  padding: 0 0.75em;
 }
 
 blockquote {


### PR DESCRIPTION
Replace CSS counter-based line numbers with a JavaScript-generated gutter element. The JS creates a separate .line-numbers div alongside the pre element using flexbox layout. This is more reliable than CSS ::before pseudo-elements and matches the pattern used by GitHub and VS Code. Line numbers are aria-hidden and outside the pre, so they won't be copied.

Closes #9

https://claude.ai/code/session_0141AxdJ1VjPXu2uUcLtojdo