### PR TITLE
Add Sveltia CMS configuration for content management

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -17,6 +17,7 @@ collections:
     folder: src/content/posts
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    summary: "{{createdAt}} - {{title}}"
     extension: md
     format: yaml-frontmatter
     fields:

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -74,6 +74,7 @@ collections:
     folder: src/content/til
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    summary: "{{createdAt}} - {{title}}"
     extension: md
     format: yaml-frontmatter
     fields:
@@ -91,6 +92,7 @@ collections:
     folder: src/content/webmarks
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    summary: "{{createdAt}} - {{title}}"
     extension: md
     format: yaml-frontmatter
     fields:

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,103 @@
+backend:
+  name: github
+  repo: galexy/galexy.github.io
+  branch: source
+
+media_folder: public/images
+public_folder: /images
+
+slug:
+  encoding: ascii
+  clean_accents: true
+  sanitize_replacement: "-"
+
+collections:
+  - name: posts
+    label: Posts
+    folder: src/content/posts
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    extension: md
+    format: yaml-frontmatter
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: Description, name: description, widget: string }
+      - { label: Created At, name: createdAt, widget: datetime,
+          format: "YYYY-MM-DDTHH:mm", date_format: "YYYY-MM-DD", time_format: "HH:mm" }
+      - { label: Tags, name: tags, widget: list, default: [],
+          field: { label: Tag, name: tag, widget: string } }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: Body, name: body, widget: markdown }
+
+  - name: snippets
+    label: Snippets
+    folder: src/content/snippets
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    identifier_field: title
+    summary: "{{createdAt}} - {{title}}"
+    extension: md
+    format: yaml-frontmatter
+    fields:
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: Created At, name: createdAt, widget: datetime,
+          format: "YYYY-MM-DDTHH:mm", date_format: "YYYY-MM-DD", time_format: "HH:mm" }
+      - { label: Tags, name: tags, widget: list, default: [],
+          field: { label: Tag, name: tag, widget: string } }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: Body, name: body, widget: markdown }
+
+  - name: quotations
+    label: Quotations
+    folder: src/content/quotations
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    identifier_field: author
+    summary: "{{createdAt}} - {{author}}"
+    extension: md
+    format: yaml-frontmatter
+    fields:
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: Author, name: author, widget: string }
+      - { label: Source, name: source, widget: string, required: false }
+      - { label: URL, name: url, widget: string, required: false }
+      - { label: Created At, name: createdAt, widget: datetime,
+          format: "YYYY-MM-DDTHH:mm", date_format: "YYYY-MM-DD", time_format: "HH:mm" }
+      - { label: Tags, name: tags, widget: list, default: [],
+          field: { label: Tag, name: tag, widget: string } }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: Body, name: body, widget: markdown }
+
+  - name: til
+    label: "Today I Learned"
+    folder: src/content/til
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    extension: md
+    format: yaml-frontmatter
+    fields:
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: URL, name: url, widget: string, required: false }
+      - { label: Created At, name: createdAt, widget: datetime,
+          format: "YYYY-MM-DDTHH:mm", date_format: "YYYY-MM-DD", time_format: "HH:mm" }
+      - { label: Tags, name: tags, widget: list, default: [],
+          field: { label: Tag, name: tag, widget: string } }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: Body, name: body, widget: markdown }
+
+  - name: webmarks
+    label: Webmarks
+    folder: src/content/webmarks
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    extension: md
+    format: yaml-frontmatter
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: URL, name: url, widget: string }
+      - { label: Created At, name: createdAt, widget: datetime,
+          format: "YYYY-MM-DDTHH:mm", date_format: "YYYY-MM-DD", time_format: "HH:mm" }
+      - { label: Tags, name: tags, widget: list, default: [],
+          field: { label: Tag, name: tag, widget: string } }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: Body, name: body, widget: markdown }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
+  <title>Content Manager - flatmap.io</title>
+</head>
+<body>
+  <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+</body>
+</html>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,3 @@
-import { defineConfig } from 'astro/config';
 import { defineCollection, z } from 'astro:content';
 
 const posts = defineCollection({
@@ -15,6 +14,7 @@ const posts = defineCollection({
 const snippets = defineCollection({
   type: 'content',
   schema: z.object({
+    title: z.string().nullish(),
     createdAt: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
@@ -24,6 +24,7 @@ const snippets = defineCollection({
 const quotations = defineCollection({
   type: 'content',
   schema: z.object({
+    title: z.string().nullish(),
     author: z.string(),
     source: z.string().optional(),
     url: z.string().optional(),
@@ -36,6 +37,8 @@ const quotations = defineCollection({
 const til = defineCollection({
   type: 'content',
   schema: z.object({
+    title: z.string().nullish(),
+    url: z.string().optional(),
     createdAt: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
@@ -60,8 +63,3 @@ export const collections = {
   til,
   webmarks,
 };
-
-export default defineConfig({
-  site: "https://flatmap.io",
-  trailingSlash: "always",
-});


### PR DESCRIPTION
## Summary
This PR adds Sveltia CMS integration to enable a headless CMS interface for managing blog content. It includes the CMS configuration file, admin interface, and updates to the content schema to support optional fields required by the CMS.

## Key Changes
- **Added `public/admin/config.yml`**: Sveltia CMS configuration file that defines:
  - GitHub backend integration pointing to the `source` branch
  - Five content collections: Posts, Snippets, Quotations, Today I Learned (TIL), and Webmarks
  - Field schemas for each collection with appropriate widgets (string, datetime, list, markdown, etc.)
  - Media folder configuration for image uploads
  - Slug generation rules with ASCII encoding and accent removal

- **Added `public/admin/index.html`**: Admin interface entry point that loads Sveltia CMS from CDN

- **Updated `src/content/config.ts`**:
  - Made `title` field optional (nullish) for Snippets and Quotations collections
  - Added optional `url` field to TIL collection
  - Removed unused `defineConfig` import and Astro site configuration (moved to appropriate config file)

## Implementation Details
- The CMS uses YAML frontmatter format for all content files
- All collections support tagging and draft status
- Timestamps use ISO 8601 format with time component
- The configuration maintains consistency with existing content structure while allowing flexibility for optional fields

https://claude.ai/code/session_01QwjEKFRJqEJMz6UtiiF1UJ