### PR TITLE
Add support for YouTube Shorts embeds

### DIFF
--- a/src/plugins/rehype-youtube-embed.mjs
+++ b/src/plugins/rehype-youtube-embed.mjs
@@ -9,6 +9,8 @@ import { visit } from 'unist-util-visit';
  *   - https://youtube.com/watch?v=VIDEO_ID
  *   - https://youtu.be/VIDEO_ID
  *   - https://www.youtube.com/embed/VIDEO_ID
+ *   - https://youtube.com/shorts/VIDEO_ID
+ *   - https://www.youtube.com/shorts/VIDEO_ID
  */
 export default function rehypeYoutubeEmbed() {
   return (tree) => {
@@ -18,9 +20,10 @@ export default function rehypeYoutubeEmbed() {
       const src = node.properties?.src;
       if (!src) return;
 
-      const videoId = extractYoutubeId(src);
-      if (!videoId) return;
+      const result = extractYoutubeId(src);
+      if (!result) return;
 
+      const { id: videoId, isShort } = result;
       const title = node.properties?.alt || 'YouTube video';
 
       // Create the iframe element
@@ -38,12 +41,12 @@ export default function rehypeYoutubeEmbed() {
         children: [],
       };
 
-      // Wrap in a responsive container
+      // Wrap in a responsive container (shorts use vertical aspect ratio)
       const wrapper = {
         type: 'element',
         tagName: 'div',
         properties: {
-          className: ['video-embed'],
+          className: isShort ? ['video-embed', 'video-embed-short'] : ['video-embed'],
         },
         children: [iframe],
       };
@@ -73,17 +76,22 @@ function extractYoutubeId(url) {
     if (hostname === 'youtube.com') {
       // Handle /watch?v=ID format
       if (parsed.pathname === '/watch') {
-        return parsed.searchParams.get('v');
+        const id = parsed.searchParams.get('v');
+        return id ? { id, isShort: false } : null;
       }
       // Handle /embed/ID format
       if (parsed.pathname.startsWith('/embed/')) {
-        return parsed.pathname.split('/embed/')[1];
+        return { id: parsed.pathname.split('/embed/')[1], isShort: false };
+      }
+      // Handle /shorts/ID format
+      if (parsed.pathname.startsWith('/shorts/')) {
+        return { id: parsed.pathname.split('/shorts/')[1], isShort: true };
       }
     }
 
     if (hostname === 'youtu.be') {
       // Handle youtu.be/ID format
-      return parsed.pathname.slice(1);
+      return { id: parsed.pathname.slice(1), isShort: false };
     }
 
     return null;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -321,6 +321,12 @@ img.img-right {
   border: 1px solid rgba(236, 234, 229, 0.2);
 }
 
+/* YouTube Shorts (9:16 vertical aspect ratio) */
+.video-embed.video-embed-short {
+  padding-bottom: 177.78%; /* 9:16 aspect ratio */
+  max-width: 360px;
+}
+
 ::selection {
   background: var(--color-terminal-accent);
   color: var(--color-terminal-bg);


### PR DESCRIPTION
## Summary
This PR adds support for embedding YouTube Shorts videos in addition to the existing standard YouTube video formats. YouTube Shorts require a different aspect ratio (9:16 vertical) compared to standard videos (16:9 horizontal).

## Key Changes
- **URL Pattern Support**: Added handling for YouTube Shorts URL formats:
  - `https://youtube.com/shorts/VIDEO_ID`
  - `https://www.youtube.com/shorts/VIDEO_ID`

- **Video Type Detection**: Modified `extractYoutubeId()` function to return an object containing both the video ID and a boolean flag indicating whether the video is a Short, instead of just the ID string

- **Responsive Container Styling**: Updated the wrapper div to conditionally apply a `video-embed-short` class for Shorts, enabling proper vertical aspect ratio (9:16 = 177.78% padding-bottom) and constraining max-width to 360px

- **CSS Styling**: Added new `.video-embed.video-embed-short` rule to handle the vertical aspect ratio and sizing for embedded Shorts

## Implementation Details
- The `extractYoutubeId()` function now returns `{ id, isShort }` object or `null`, allowing callers to differentiate between standard videos and Shorts
- Shorts are identified by the `/shorts/` pathname pattern
- The responsive container wrapper dynamically applies the appropriate CSS class based on the video type
- All existing YouTube URL formats continue to work as before

https://claude.ai/code/session_01WQ6uWMExrra5zqZqQM4BpH