### PR TITLE
Use CSS aspect-ratio for YouTube Shorts video embeds

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -323,8 +323,9 @@ img.img-right {
 
 /* YouTube Shorts (9:16 vertical aspect ratio) */
 .video-embed.video-embed-short {
-  padding-bottom: 177.78%; /* 9:16 aspect ratio */
   max-width: 360px;
+  padding-bottom: 0;
+  aspect-ratio: 9 / 16;
 }
 
 ::selection {


### PR DESCRIPTION
## Summary
Updated the YouTube Shorts video embed styling to use the modern CSS `aspect-ratio` property instead of the padding-bottom hack for maintaining a 9:16 aspect ratio.

## Key Changes
- Replaced `padding-bottom: 177.78%` with the `aspect-ratio: 9 / 16` CSS property
- Set `padding-bottom: 0` to remove the previous aspect ratio calculation method
- Maintained `max-width: 360px` constraint for responsive sizing

## Implementation Details
This change modernizes the aspect ratio handling for vertical video embeds by leveraging native CSS support for `aspect-ratio`, which is now widely supported across modern browsers. This approach is cleaner and more maintainable than the traditional padding-bottom percentage hack, while achieving the same visual result with better performance and readability.

https://claude.ai/code/session_01H78kWkQ4THsAS4jkRRrbkH