### PR TITLE
Extract about section to dedicated page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -96,6 +96,11 @@ const canonicalURL = Astro.site ? new URL(Astro.url.pathname, Astro.site) : new 
               </a>
             </li>
             <li>
+              <a href="/about" class="hover:text-[var(--color-terminal-accent)] transition-colors">
+                about
+              </a>
+            </li>
+            <li>
               <a href="/rss.xml" class="hover:text-[var(--color-terminal-accent)] transition-colors">
                 rss
               </a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,23 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="About Me" description="About Galex Yen - software engineer, AI/ML engineer, and engineering manager">
+  <div class="space-y-8">
+    <section>
+      <h1 class="text-4xl font-bold mb-4 text-[var(--color-terminal-accent)]">
+        $ whoami
+      </h1>
+      <p class="text-lg opacity-90 mb-4">
+      My name is Galex Yen. I was a software and AI/ML engineer and later engineering manager for most of my career.
+      I worked on the compiler for SQL Server, the query engine for StreamInsight, built the data systems
+      at Remitly from the ground up and led the first data engineering, ML and business analytics teams there.
+      Most recently, I built AI agents at Thunk.ai. I'm now retired and advising startups on how to build AI
+      agents.
+      </p>
+      <p class="opacity-75">
+      I'm constantly learning new things. This blog is my attempt to <a href="https://www.swyx.io/learn-in-public" class="text-[var(--color-terminal-accent)] hover:underline">learn in public</a>.
+      </p>
+    </section>
+  </div>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -119,24 +119,6 @@ const groupedItems = allItems.reduce((groups, item) => {
 <BaseLayout title="My Blog - Home" description="A terminal-inspired blog with posts, snippets, quotations, TIL, and webmarks">
   <div class="space-y-8">
     <section>
-      <h1 class="text-4xl font-bold mb-4 text-[var(--color-terminal-accent)]">
-        $ whoami
-      </h1>
-      <p class="text-lg opacity-90 mb-4">
-      My name is Galex Yen. I was a software and AI/ML engineer and later engineering manager for most of my career. 
-      I worked on the compiler for SQL Server, the query engine for StreamInsight, built the data systems
-      at Remitly from the ground up and led the first data engineering, ML and business analytics teams there.
-      Most recently, I built AI agents at Thunk.ai. I'm now retired and advising startups on how to build AI
-      agents.
-      </p>
-      <p class="opacity-75">
-      I'm constantly learning new things. This blog is my attempt to <a href="https://www.swyx.io/learn-in-public" class="text-[var(--color-terminal-accent)] hover:underline">learn in public</a>.
-      </p>
-    </section>
-
-    <hr />
-
-    <section>
       <h2 class="text-3xl font-bold mb-6 text-[var(--color-terminal-fg)]">
         Recent Activity
       </h2>


### PR DESCRIPTION
## Summary
Refactored the about/bio section from the homepage into a dedicated `/about` page to improve site organization and navigation.

## Key Changes
- Created new `src/pages/about.astro` page containing the "whoami" bio section previously on the homepage
- Removed the about section from `src/pages/index.astro` to declutter the homepage and focus it on recent activity
- Added "about" navigation link to `src/layouts/BaseLayout.astro` header navigation menu

## Implementation Details
- The about page uses the same `BaseLayout` component and styling as other pages
- The bio content remains unchanged, only relocated to its own dedicated page
- Navigation link is positioned before the RSS feed link in the header menu
- Maintains the terminal-inspired aesthetic with the `$ whoami` heading and existing color scheme

https://claude.ai/code/session_0199B3cFRxsrHywTficwy8g3