### PR TITLE
Add table of contents sidebar to blog posts

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,31 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props;
+
+// Only include h2 and h3 headings
+const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+---
+
+{tocHeadings.length > 0 && (
+  <nav class="toc-nav" aria-label="Table of Contents">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list">
+      {tocHeadings.map((heading) => (
+        <li class:list={["toc-item", { "toc-item-nested": heading.depth === 3 }]}>
+          <a href={`#${heading.slug}`} class="toc-link" data-heading-slug={heading.slug}>
+            {heading.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import Comments from '../../../../components/Comments.astro';
+import TableOfContents from '../../../../components/TableOfContents.astro';
 import { getPostDateAndSlug } from '../../../../lib/posts';
 
 interface Props {
@@ -31,7 +32,7 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await post.render();
+const { Content, headings } = await post.render();
 
 const { date } = getPostDateAndSlug(post);
 const formattedDate = date.toLocaleDateString('en-US', {
@@ -42,31 +43,86 @@ const formattedDate = date.toLocaleDateString('en-US', {
 ---
 
 <BaseLayout title={post.data.title} description={post.data.description}>
-  <article class="post-content">
-    <header class="mb-8">
-      <h1 class="text-4xl font-bold mb-2">{post.data.title}</h1>
-      <div class="text-sm opacity-70 mb-4">
-        <time datetime={post.data.createdAt.toISOString()}>
-          {formattedDate}
-        </time>
-      </div>
-      {post.data.tags.length > 0 && (
-        <div class="flex gap-2 flex-wrap">
-          {post.data.tags.map((tag) => (
-            <a
-              href={`/tags/${tag}`}
-              class="text-sm px-2 py-1 border border-[var(--color-terminal-accent)] hover:bg-[var(--color-terminal-accent)]/10 transition-colors"
-            >
-              #{tag}
-            </a>
-          ))}
-        </div>
-      )}
-    </header>
+  <div class="post-layout">
+    <aside class="toc-sidebar">
+      <TableOfContents headings={headings} />
+    </aside>
+    <div class="post-main">
+      <article class="post-content">
+        <header class="mb-8">
+          <h1 class="text-4xl font-bold mb-2">{post.data.title}</h1>
+          <div class="text-sm opacity-70 mb-4">
+            <time datetime={post.data.createdAt.toISOString()}>
+              {formattedDate}
+            </time>
+          </div>
+          {post.data.tags.length > 0 && (
+            <div class="flex gap-2 flex-wrap">
+              {post.data.tags.map((tag) => (
+                <a
+                  href={`/tags/${tag}`}
+                  class="text-sm px-2 py-1 border border-[var(--color-terminal-accent)] hover:bg-[var(--color-terminal-accent)]/10 transition-colors"
+                >
+                  #{tag}
+                </a>
+              ))}
+            </div>
+          )}
+        </header>
 
-    <div class="prose prose-invert max-w-none">
-      <Content />
+        <div class="prose prose-invert max-w-none">
+          <Content />
+        </div>
+      </article>
+      <Comments />
     </div>
-  </article>
-  <Comments />
+  </div>
+
+  <script>
+    function initTocHighlight() {
+      const tocLinks = document.querySelectorAll<HTMLAnchorElement>('.toc-link');
+      if (tocLinks.length === 0) return;
+
+      const headingElements = Array.from(tocLinks).map((link) => {
+        const slug = link.dataset.headingSlug;
+        return slug ? document.getElementById(slug) : null;
+      }).filter((el): el is HTMLElement => el !== null);
+
+      if (headingElements.length === 0) return;
+
+      // Smooth scroll on click
+      tocLinks.forEach((link) => {
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          const slug = link.dataset.headingSlug;
+          const target = slug ? document.getElementById(slug) : null;
+          if (target) {
+            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            history.pushState(null, '', `#${slug}`);
+          }
+        });
+      });
+
+      // Intersection observer for active state
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              tocLinks.forEach((link) => link.classList.remove('toc-link-active'));
+              const activeLink = document.querySelector(
+                `.toc-link[data-heading-slug="${entry.target.id}"]`
+              );
+              if (activeLink) activeLink.classList.add('toc-link-active');
+            }
+          });
+        },
+        { rootMargin: '0px 0px -80% 0px', threshold: 0 }
+      );
+
+      headingElements.forEach((el) => observer.observe(el));
+    }
+
+    initTocHighlight();
+    document.addEventListener('astro:after-swap', initTocHighlight);
+  </script>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -329,6 +329,96 @@ img.img-right {
   margin-inline: auto;
 }
 
+/* Table of Contents layout */
+.post-layout {
+  position: relative;
+}
+
+.toc-sidebar {
+  display: none;
+}
+
+@media (min-width: 1280px) {
+  .toc-sidebar {
+    display: block;
+    position: absolute;
+    left: -250px;
+    top: 0;
+    width: 220px;
+  }
+
+  .toc-nav {
+    position: sticky;
+    top: 2rem;
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+  }
+}
+
+.toc-title {
+  font-size: 0.8em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-terminal-accent);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgba(236, 234, 229, 0.15);
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-list li::before {
+  content: none;
+}
+
+.toc-item {
+  margin: 0;
+}
+
+.toc-item-nested {
+  padding-left: 12px;
+}
+
+.toc-link {
+  display: block;
+  padding: 4px 0;
+  font-size: 0.75em;
+  line-height: 1.4;
+  color: rgba(236, 234, 229, 0.5);
+  text-decoration: none;
+  transition: color 0.15s;
+  border-left: 2px solid transparent;
+  padding-left: 8px;
+}
+
+.toc-link:hover {
+  color: var(--color-terminal-fg);
+  text-decoration: none;
+}
+
+.toc-link-active {
+  color: var(--color-terminal-accent);
+  border-left-color: var(--color-terminal-accent);
+}
+
+/* Scrollbar for TOC */
+.toc-nav::-webkit-scrollbar {
+  width: 3px;
+}
+
+.toc-nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.toc-nav::-webkit-scrollbar-thumb {
+  background: rgba(236, 234, 229, 0.2);
+}
+
 ::selection {
   background: var(--color-terminal-accent);
   color: var(--color-terminal-bg);


### PR DESCRIPTION
## Summary
This PR adds an interactive table of contents (TOC) sidebar to blog post pages, displayed on the left side on larger screens. The TOC automatically highlights the currently visible section as users scroll through the post.

## Key Changes
- **New TableOfContents component** (`src/components/TableOfContents.astro`): Renders a navigation sidebar with h2 and h3 headings extracted from post content
- **Updated post layout** (`src/pages/[year]/[month]/[day]/[slug].astro`):
  - Restructured page layout to accommodate the sidebar using a two-column design
  - Extract `headings` from post render output and pass to TableOfContents component
  - Added client-side script for smooth scrolling and active link highlighting
- **New styling** (`src/styles/global.css`):
  - TOC sidebar positioned absolutely on the left (hidden on screens < 1280px)
  - Sticky positioning for the TOC nav to remain visible while scrolling
  - Styling for TOC links with hover and active states
  - Custom scrollbar styling for the TOC container

## Implementation Details
- The TOC sidebar uses an Intersection Observer API to track which heading is currently in view and highlights the corresponding link
- Smooth scroll behavior is implemented via `scrollIntoView()` with history state management
- The layout gracefully degrades on smaller screens (sidebar hidden, full-width content)
- TOC updates are re-initialized on Astro view transitions (`astro:after-swap` event)

https://claude.ai/code/session_015NWppaMNheupisCye2qi3E