### PR TITLE
Add Shiki code block transformers for diff, highlight, and metadata

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,27 @@ import remarkFigureCaption from '@microflash/remark-figure-caption';
 import rehypeKatex from 'rehype-katex';
 import rehypeObsidianImages from './src/plugins/rehype-obsidian-images.mjs';
 import rehypeYoutubeEmbed from './src/plugins/rehype-youtube-embed.mjs';
+import {
+  transformerNotationDiff,
+  transformerNotationHighlight,
+  transformerNotationWordHighlight,
+  transformerMetaHighlight,
+} from '@shikijs/transformers';
+
+/** Custom transformer to extract title="filename" from code block meta */
+function transformerMetaTitle() {
+  return {
+    name: 'meta-title',
+    pre(node) {
+      const meta = this.options.meta?.__raw;
+      if (!meta) return;
+      const match = meta.match(/title="([^"]+)"/);
+      if (match) {
+        node.properties['data-title'] = match[1];
+      }
+    },
+  };
+}
 
 // https://astro.build/config
 export default defineConfig({
@@ -17,7 +38,14 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       theme: 'github-dark',
-      wrap: true
+      wrap: true,
+      transformers: [
+        transformerNotationDiff(),
+        transformerNotationHighlight(),
+        transformerNotationWordHighlight(),
+        transformerMetaHighlight(),
+        transformerMetaTitle(),
+      ],
     },
     remarkPlugins: [remarkMath, remarkFigureCaption],
     rehypePlugins: [rehypeKatex, rehypeObsidianImages, rehypeYoutubeEmbed]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/rss": "^4.0.14",
         "@astrojs/sitemap": "^3.2.1",
         "@microflash/remark-figure-caption": "^2.0.2",
+        "@shikijs/transformers": "^4.0.2",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.1.4",
         "rehype-katex": "^7.0.1",
@@ -1694,6 +1695,33 @@
         "@shikijs/types": "3.20.0"
       }
     },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@shikijs/themes": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.20.0.tgz",
@@ -1701,6 +1729,48 @@
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.20.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.0.2.tgz",
+      "integrity": "sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.2.1",
     "@microflash/remark-figure-caption": "^2.0.2",
+    "@shikijs/transformers": "^4.0.2",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.1.4",
     "rehype-katex": "^7.0.1",

--- a/src/scripts/code-blocks.js
+++ b/src/scripts/code-blocks.js
@@ -7,13 +7,22 @@ document.addEventListener("DOMContentLoaded", () => {
     pre.parentNode?.insertBefore(wrapper, pre);
     wrapper.appendChild(pre);
 
-    // Get language from data attribute
+    // Get language and optional filename from data attributes
     const language = pre.getAttribute("data-language") || "text";
+    const title = pre.getAttribute("data-title");
 
-    // Create title bar with language label
+    // Create title bar with filename or language label
     const titleBar = document.createElement("div");
     titleBar.className = "code-title";
-    titleBar.textContent = language;
+
+    const labelSpan = document.createElement("span");
+    if (title) {
+      labelSpan.textContent = title;
+      labelSpan.title = language;
+    } else {
+      labelSpan.textContent = language;
+    }
+    titleBar.appendChild(labelSpan);
 
     // Add copy button if clipboard API is available
     if (navigator.clipboard) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,6 +127,56 @@ pre code {
   font-size: 0.9em;
 }
 
+/* Shiki transformer: diff notation */
+pre .line.diff.add {
+  background-color: rgba(46, 160, 67, 0.2);
+}
+
+pre .line.diff.add::before {
+  content: "+";
+  position: absolute;
+  left: 4px;
+  color: #3fb950;
+}
+
+pre .line.diff.remove {
+  background-color: rgba(248, 81, 73, 0.2);
+}
+
+pre .line.diff.remove::before {
+  content: "-";
+  position: absolute;
+  left: 4px;
+  color: #f85149;
+}
+
+pre .line.diff {
+  position: relative;
+  padding-left: 20px;
+  margin-left: -15px;
+  margin-right: -15px;
+  padding-right: 15px;
+}
+
+/* Shiki transformer: line highlight */
+pre .line.highlighted {
+  background-color: rgba(238, 195, 94, 0.12);
+  margin-left: -15px;
+  margin-right: -15px;
+  padding-left: 13px;
+  padding-right: 15px;
+  border-left: 2px solid var(--color-terminal-accent);
+}
+
+/* Shiki transformer: word highlight */
+pre .highlighted-word {
+  background-color: rgba(238, 195, 94, 0.25);
+  border: 1px solid rgba(238, 195, 94, 0.4);
+  border-radius: 2px;
+  padding: 1px 3px;
+  margin: -1px -3px;
+}
+
 /* Line numbers gutter */
 .code-wrapper {
   display: flex;


### PR DESCRIPTION
## Summary
Enhanced code block rendering with Shiki transformers to support diff notation, line/word highlighting, and custom filename metadata in code blocks.

## Key Changes
- **Shiki Transformers Integration**: Added four Shiki transformers to `astro.config.mjs`:
  - `transformerNotationDiff()` - Enables diff notation with `// [!code ++]` and `// [!code --]` syntax
  - `transformerNotationHighlight()` - Enables line highlighting with `// [!code highlight]` syntax
  - `transformerNotationWordHighlight()` - Enables word highlighting with `// [!code word:text]` syntax
  - `transformerMetaHighlight()` - Provides meta highlighting capabilities

- **Custom Meta Title Transformer**: Implemented `transformerMetaTitle()` to extract `title="filename"` from code block metadata and store it as a `data-title` attribute

- **Styling**: Added comprehensive CSS rules in `global.css` for:
  - Diff notation (added/removed lines with `+`/`-` indicators and colored backgrounds)
  - Line highlighting (yellow accent with left border)
  - Word highlighting (inline highlighting with border and padding)

- **Code Block UI Enhancement**: Updated `code-blocks.js` to:
  - Extract and display custom filename from `data-title` attribute
  - Show language as tooltip when filename is present
  - Maintain backward compatibility with language-only display

## Implementation Details
- Diff lines use green (`#3fb950`) for additions and red (`#f85149`) for removals with semi-transparent backgrounds
- Highlighted lines use a yellow accent color with a 2px left border
- Word highlights have subtle borders and rounded corners for inline emphasis
- The custom title transformer parses the raw metadata string to extract filename information

https://claude.ai/code/session_01DLrzc42SCFgKo2vfLPaYCf