### PR TITLE
Add featured content section to homepage

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,6 +8,7 @@ const posts = defineCollection({
     createdAt: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
+    featured: z.boolean().default(false),
   }),
 });
 
@@ -18,6 +19,7 @@ const snippets = defineCollection({
     createdAt: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
+    featured: z.boolean().default(false),
   }),
 });
 
@@ -31,6 +33,7 @@ const quotations = defineCollection({
     createdAt: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
+    featured: z.boolean().default(false),
   }),
 });
 
@@ -42,6 +45,7 @@ const til = defineCollection({
     createdAt: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
+    featured: z.boolean().default(false),
   }),
 });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -100,6 +100,55 @@ const allItems: TimelineItemData[] = [
 // Sort by date descending
 allItems.sort((a, b) => b.date.getTime() - a.date.getTime());
 
+// Collect featured items (excluding webmarks)
+const featuredItems: TimelineItemData[] = [
+  ...posts.filter((p) => p.data.featured).map((post) => {
+    const { date } = getPostDateAndSlug(post);
+    return {
+      type: 'post' as const,
+      date,
+      url: getPostUrl(post),
+      title: post.data.title,
+      description: post.data.description,
+      tags: post.data.tags,
+      time: formatTime(date),
+    };
+  }),
+  ...snippets.filter((s) => s.data.featured).map((snippet) => {
+    const { date } = getSnippetDateAndSlug(snippet);
+    return {
+      type: 'snippet' as const,
+      date,
+      url: getSnippetUrl(snippet),
+      tags: snippet.data.tags,
+      description: getSnippetPreview(snippet),
+      time: formatTime(date),
+    };
+  }),
+  ...quotations.filter((q) => q.data.featured).map((quotation) => {
+    const { date } = getQuotationDateAndSlug(quotation);
+    return {
+      type: 'quotation' as const,
+      date,
+      url: getQuotationUrl(quotation),
+      description: `"${getQuotationPreview(quotation)}" — ${quotation.data.author}`,
+      tags: quotation.data.tags,
+      time: formatTime(date),
+    };
+  }),
+  ...tils.filter((t) => t.data.featured).map((til) => {
+    const { date } = getTilDateAndSlug(til);
+    return {
+      type: 'til' as const,
+      date,
+      url: getTilUrl(til),
+      description: getTilPreview(til),
+      tags: til.data.tags,
+      time: formatTime(date),
+    };
+  }),
+].sort((a, b) => b.date.getTime() - a.date.getTime());
+
 // Group by date
 const groupedItems = allItems.reduce((groups, item) => {
   const dateStr = item.date.toLocaleDateString('en-US', {
@@ -118,6 +167,26 @@ const groupedItems = allItems.reduce((groups, item) => {
 
 <BaseLayout title="My Blog - Home" description="A terminal-inspired blog with posts, snippets, quotations, TIL, and webmarks">
   <div class="space-y-8">
+    {featuredItems.length > 0 && (
+      <section class="featured-section border border-[var(--color-terminal-accent)]/30 p-6">
+        <h2 class="text-xl font-bold mb-4 text-[var(--color-terminal-accent)] uppercase tracking-wider">
+          ★ Featured
+        </h2>
+        <div class="space-y-2">
+          {featuredItems.map((item) => (
+            <TimelineItem
+              type={item.type}
+              title={item.title}
+              description={item.description}
+              url={item.url}
+              tags={item.tags}
+              time={item.time}
+            />
+          ))}
+        </div>
+      </section>
+    )}
+
     <section>
       <h2 class="text-3xl font-bold mb-6 text-[var(--color-terminal-fg)]">
         Recent Activity


### PR DESCRIPTION
## Summary
This PR adds a "Featured" section to the homepage that displays curated content from posts, snippets, quotations, and TILs. Content creators can now mark items as featured to highlight them prominently at the top of the homepage.

## Key Changes
- **Content schema updates**: Added `featured: boolean` field (default `false`) to all content collections (posts, snippets, quotations, and TIL) in `src/content/config.ts`
- **Featured items collection**: Created a new `featuredItems` array in `src/pages/index.astro` that filters and transforms all content types by their `featured` flag, excluding webmarks
- **Homepage UI**: Added a new "Featured" section at the top of the homepage that displays featured items in a styled container with a terminal-inspired aesthetic, only rendering when featured items exist

## Implementation Details
- Featured items are collected from all content types (posts, snippets, quotations, TILs) using the same transformation logic as the main timeline
- Items are sorted by date in descending order within the featured section
- The featured section uses the existing `TimelineItem` component for consistent styling and display
- The section includes a star icon (★) and "Featured" heading with terminal-inspired styling (accent color, uppercase, letter spacing)
- Webmarks are intentionally excluded from the featured section

https://claude.ai/code/session_011znJUSCTCyb6W1tQVe7z3J