### PR TITLE
Add TableOfContents component for documentation pages

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,31 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props;
+
+// Only include h2 and h3 headings
+const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+---
+
+{tocHeadings.length > 0 && (
+  <nav class="toc-nav" aria-label="Table of Contents">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list">
+      {tocHeadings.map((heading) => (
+        <li class:list={["toc-item", { "toc-item-nested": heading.depth === 3 }]}>
+          <a href={`#${heading.slug}`} class="toc-link" data-heading-slug={heading.slug}>
+            {heading.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}


### PR DESCRIPTION
## Summary
This PR introduces a new `TableOfContents` Astro component that automatically generates a navigation menu for documentation pages based on heading structure.

## Key Changes
- **New Component**: Created `src/components/TableOfContents.astro` that accepts an array of headings and renders a table of contents
- **Heading Filtering**: Filters headings to include only h2 and h3 levels (depth 2-3), excluding h1 and deeper headings
- **Semantic Navigation**: Uses proper `<nav>` element with `aria-label` for accessibility
- **Nested Styling**: Applies conditional CSS class (`toc-item-nested`) to h3 headings for visual hierarchy
- **Anchor Links**: Generates links that point to heading slugs for smooth navigation within the page

## Implementation Details
- Component accepts a `headings` prop containing objects with `depth`, `slug`, and `text` properties
- Only renders the navigation when there are qualifying headings (h2 or h3)
- Uses Astro's `class:list` directive for conditional class application based on heading depth
- Includes a "On this page" title for context

https://claude.ai/code/session_01MpYBATXVNt5gWy43fHwcsX